### PR TITLE
Separate setup instructions from template talk overview

### DIFF
--- a/2018-03-18/slides-http4s-talk/README.md
+++ b/2018-03-18/slides-http4s-talk/README.md
@@ -2,15 +2,3 @@ Building a REST API using Http4s (Abstracting over the effect type)
 ===================================================================
 
 Slides of the talk given by [Gabriel Volpe](https://github.com/gvolpe) on behalf of [Paidy](https://engineering.paidy.com/) at the [Scala Matsuri 2018 unconference](http://2018.scalamatsuri.org/index_en.html#day2).
-
-### How to start the server
-
-You need to install `nodejs` and `npm`.
-
-```bash
-> cd slides-directory/
-> npm install
-> npm start
-```
-
-Server will start at http://localhost:8000.

--- a/2018-06-20/tokyo-meetup-cats-effect/README.md
+++ b/2018-06-20/tokyo-meetup-cats-effect/README.md
@@ -2,15 +2,3 @@ Cats Effect: The IO Monad for Scala
 ===================================
 
 Slides of the talk given by [Gabriel Volpe](https://gvolpe.github.io/) at the [Tokyo Scala Meetup](https://www.meetup.com/Tokyo-Scala-Developers/events/250976376/) on June 2018.
-
-### How to start the server
-
-You need to install `nodejs` and `npm`.
-
-```bash
-> cd slides-directory/
-> npm install
-> npm start
-```
-
-Server will start at http://localhost:8000.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,28 @@ Public talks given by different speakers in representation of [Paidy Engineering
 - [Cats Effect: The IO Monad for Scala](2018-06-20/tokyo-meetup-cats-effect/) by [Gabriel Volpe](https://github.com/gvolpe) at the [Tokyo Scala Developers Meetup](https://www.meetup.com/Tokyo-Scala-Developers/).
 - [Building a REST API using Http4s (Abstracting over the effect type)](2018-03-18/) by [Gabriel Volpe](https://github.com/gvolpe) at [Scala Matsuri 2018](http://2018.scalamatsuri.org/index_en.html).
 
-Adding your own talk instructions in [`template/README.md`](https://github.com/paidy/talks/tree/master/template/README.md)
+Adding your own talk
+=====
+
+### Setup
+
+- Copy `/template` to `/$year-month-day/$your-talk-title`.
+- Take a look at the other templates to see how to structure `./index.html` and `*.md` files.
+- Use `./assets` for local assets, and [`/static/assets`](https://github.com/paidy/talks/tree/master/static/assets) for 'global' Paidy assets.
+- Add your talk to the list of talks in the [project README](https://github.com/paidy/talks/blob/master/README.md).
+
+### How to start the server
+
+You need to install `nodejs` and `npm`.
+
+```bash
+> cd /$date/$title
+> npm install
+> npm start
+```
+
+Server will start at http://localhost:8000.
+
+### How to print your slides
+
+Loading `http://localhost:8000/?print-pdf/gi` in a browser will render your slides in a format suitable for printing or PDF download

--- a/template/README.md
+++ b/template/README.md
@@ -2,25 +2,3 @@
 ====================
 
 Slides of the talk given by [Your Name](https://github.com/username) at the [Event](https://www.meetup.com/Tokyo-Scala-Developers/) on [month] [year].
-
-### Setup
-
-- Copy `/template` to your `/$year-$/$title`.
-- Take a look at the other templates to see how to structure `./index.html`.
-  - Same goes for markdown syntax.
-- Use `./assets` for local assets.
-  - 'Global' Paidy assets are in [`/static/assets`](https://github.com/paidy/talks/tree/master/static/assets).
-  
- - Add your talk to the list of talks in the [project README](https://github.com/paidy/talks/blob/master/README.md).
-
-### How to start the server
-
-You need to install `nodejs` and `npm`.
-
-```bash
-> cd /$date/$title
-> npm install
-> npm start
-```
-
-Server will start at http://localhost:8000.


### PR DESCRIPTION
I don't think the new talk setup instructions shouldn't be in every talk, this PR moves the instructions to the root README, and leaves the per-talk READMEs to be a talk-specific overview.